### PR TITLE
Fix duplicate OMI notifications

### DIFF
--- a/server.js
+++ b/server.js
@@ -1558,7 +1558,7 @@ app.post('/omi-webhook', async (req, res) => {
       const contentHash = Buffer.from(fullTranscript).toString('base64');
       if (processedContent.has(session_id) && processedContent.get(session_id).includes(contentHash)) {
         console.log('⏭️ Skipping duplicate transcript content:', fullTranscript);
-        return res.status(200).json({ message: 'Content already processed' });
+        return res.status(200).json({ status: 'Content already processed' });
       }
       
       // Track this content as processed
@@ -1593,7 +1593,7 @@ I can remember things for you and help organize your thoughts!`;
       sessionTranscripts.delete(session_id);
       console.log('🧹 Cleared session transcript for help request:', session_id);
       return res.status(200).json({ 
-        message: 'You can talk to me naturally! Try asking questions or giving commands.',
+        status: 'You can talk to me naturally! Try asking questions or giving commands.',
         help_response: helpMessage,
         instructions: 'Ask questions naturally or use "Hey Omi" to be explicit.',
         conversation_context: 'maintained'
@@ -1871,7 +1871,7 @@ ${history.map(msg => `${msg.role === 'user' ? 'User' : 'Assistant'}: ${msg.conte
     if (!question) {
       console.log('⏭️ Skipping transcript - no question after "hey omi"');
       return res.status(200).json({ 
-        message: 'Transcript ignored - no question provided' 
+        status: 'Transcript ignored - no question provided' 
       });
     }
     
@@ -2055,10 +2055,9 @@ ${history.map(msg => `${msg.role === 'user' ? 'User' : 'Assistant'}: ${msg.conte
          // Store conversation history even when rate limited
          manageConversationHistory(session_id, question, aiResponse);
          
-         // Still return the AI response, but note the rate limit
+         // Still return the AI response, but note the rate limit (without message field to prevent duplicate notifications)
          res.status(200).json({
            success: true,
-           message: aiResponse,
            question: question,
            ai_response: aiResponse,
            omi_response: null,
@@ -2092,10 +2091,9 @@ ${history.map(msg => `${msg.role === 'user' ? 'User' : 'Assistant'}: ${msg.conte
      const requestDuration = Date.now() - requestStartTime;
      updatePerformanceMetrics('request', requestDuration);
      
-     // Return success response
+     // Return success response (without message field to prevent duplicate notifications)
      res.status(200).json({
        success: true,
-       message: aiResponse,
        question: question,
        ai_response: aiResponse,
        omi_response: omiResponse,


### PR DESCRIPTION
Remove `message` field from webhook responses to prevent duplicate OMI notifications.

OMI was interpreting both the explicit `sendOmiNotification` call and the `message` field in the webhook's JSON response body as separate notifications. Removing the `message` field from responses where `sendOmiNotification` is also called ensures only one notification is sent per AI response. Other `message` fields were changed to `status` for consistency.

---
<a href="https://cursor.com/background-agent?bcId=bc-dbbebbe6-9e42-4f81-a479-4a174a88d719">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-dbbebbe6-9e42-4f81-a479-4a174a88d719">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

