### PR TITLE
Testing commenting out the message parameters in the success response

### DIFF
--- a/server.js
+++ b/server.js
@@ -445,7 +445,7 @@ app.post('/omi-webhook', async (req, res) => {
      // Return success response
      res.status(200).json({
        success: true,
-       message: aiResponse,
+       //message: aiResponse,
        question: question,
        ai_response: aiResponse,
        omi_response: omiResponse,


### PR DESCRIPTION
Removing aiResponse message in the res.status(200).json success response. This shouldn't be needed since the message is already sent once by the function.