### PR TITLE
Fix notification content display after duplicate removal

### DIFF
--- a/server.js
+++ b/server.js
@@ -430,37 +430,11 @@ app.post('/omi-webhook', async (req, res) => {
          }
      }
     
-         // Send response back to Omi using the new function
-     let omiResponse = null;
-     let rateLimitInfo = null;
-     
-     try {
-       omiResponse = await sendOmiNotification(session_id, aiResponse);
-       console.log('📤 Successfully sent response to Omi:', omiResponse);
-     } catch (error) {
-       if (error.message.includes('Rate limit exceeded')) {
-         rateLimitInfo = getRateLimitStatus(session_id);
-         console.log('⚠️ Rate limit exceeded for user:', session_id, rateLimitInfo);
-         
-         // Rate limited - return non-talking response (AI response already generated but not sent)
-         res.status(204).send(); // No Content - rate limited, no notification sent
-         
-         // Clear the session transcript after response
-         sessionTranscripts.delete(session_id);
-         console.log('🧹 Cleared session transcript for:', session_id);
-         return;
-       } else {
-         // Re-throw other errors
-         throw error;
-       }
-     }
-     
-     // Clear the session transcript after successful processing
-     sessionTranscripts.delete(session_id);
-     console.log('🧹 Cleared session transcript for:', session_id);
-     
-     // Return success response (non-talking to avoid duplicate messages)
-     res.status(204).send(); // No Content - notification already sent via sendOmiNotification
+        // Return AI response in body so Omi creates the chat message and handles notification
+    sessionTranscripts.delete(session_id);
+    console.log('🧹 Cleared session transcript for:', session_id);
+
+    return res.status(200).json({ message: aiResponse });
     
   } catch (error) {
     console.error('❌ Error processing webhook:', error);


### PR DESCRIPTION
Return AI response in webhook body to ensure a single notification and display chat content.

The previous implementation sent a direct notification via `sendOmiNotification` and then returned a 204, which led to duplicate notifications. When `sendOmiNotification` was removed, only one notification was received, but the chat content was missing upon opening. This change ensures Omi processes the AI response from the webhook body, creating a single notification that correctly displays the chat content when clicked.

---
<a href="https://cursor.com/background-agent?bcId=bc-b0c0d8dd-b002-4387-9618-c2c77340b804">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b0c0d8dd-b002-4387-9618-c2c77340b804">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

