### PR TITLE
Fix notification content display after duplicate removal

### DIFF
--- a/server.js
+++ b/server.js
@@ -430,37 +430,10 @@ app.post('/omi-webhook', async (req, res) => {
          }
      }
     
-         // Send response back to Omi using the new function
-     let omiResponse = null;
-     let rateLimitInfo = null;
-     
-     try {
-       omiResponse = await sendOmiNotification(session_id, aiResponse);
-       console.log('📤 Successfully sent response to Omi:', omiResponse);
-     } catch (error) {
-       if (error.message.includes('Rate limit exceeded')) {
-         rateLimitInfo = getRateLimitStatus(session_id);
-         console.log('⚠️ Rate limit exceeded for user:', session_id, rateLimitInfo);
-         
-         // Rate limited - return non-talking response (AI response already generated but not sent)
-         res.status(204).send(); // No Content - rate limited, no notification sent
-         
-         // Clear the session transcript after response
-         sessionTranscripts.delete(session_id);
-         console.log('🧹 Cleared session transcript for:', session_id);
-         return;
-       } else {
-         // Re-throw other errors
-         throw error;
-       }
-     }
-     
-     // Clear the session transcript after successful processing
-     sessionTranscripts.delete(session_id);
-     console.log('🧹 Cleared session transcript for:', session_id);
-     
-     // Return success response (non-talking to avoid duplicate messages)
-     res.status(204).send(); // No Content - notification already sent via sendOmiNotification
+    // Return response so Omi shows content in chat and sends a single notification
+    sessionTranscripts.delete(session_id);
+    console.log('🧹 Cleared session transcript for:', session_id);
+    return res.status(200).json({ message: aiResponse });
     
   } catch (error) {
     console.error('❌ Error processing webhook:', error);


### PR DESCRIPTION
Return AI response in webhook body and remove manual notification to fix duplicate notifications and display message content.

The previous implementation used a manual notification call followed by a `204 No Content` response, which led to duplicate notifications. When the manual notification was removed, the `204` response meant Omi had no content to display. This change ensures Omi receives the AI response directly in the webhook body, allowing it to generate a single notification and display the message content correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-43f601cc-ad63-46de-a46f-2d7f6fb13f96">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-43f601cc-ad63-46de-a46f-2d7f6fb13f96">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

