### PR TITLE
Fix openai input type error

### DIFF
--- a/server.js
+++ b/server.js
@@ -438,7 +438,7 @@ app.post('/omi-webhook', async (req, res) => {
         const response = await openai.responses.create({
             model: OPENAI_MODEL,
             tools: [WEB_SEARCH_TOOL],
-            input: { role: 'user', content: question },
+            input: question,
             conversation: conversationId,
         });
         


### PR DESCRIPTION
Fix OpenAI Responses API `input` type to a string to resolve `BadRequestError` and enable conversation memory.

---
<a href="https://cursor.com/background-agent?bcId=bc-2ae923bb-23fa-4b3e-8538-75f580656fb9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2ae923bb-23fa-4b3e-8538-75f580656fb9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

