### PR TITLE
Fix openai input type error

### DIFF
--- a/server.js
+++ b/server.js
@@ -438,7 +438,7 @@ app.post('/omi-webhook', async (req, res) => {
         const response = await openai.responses.create({
             model: OPENAI_MODEL,
             tools: [WEB_SEARCH_TOOL],
-            input: { role: 'user', content: question },
+            input: question,
             conversation: conversationId,
         });
         


### PR DESCRIPTION
Fix OpenAI API `input` type error by passing `question` as a string instead of an object to enable conversation memory.

---
<a href="https://cursor.com/background-agent?bcId=bc-f12fe3da-c1a1-48b6-aebb-329e6c9fb545">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f12fe3da-c1a1-48b6-aebb-329e6c9fb545">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

