### PR TITLE
Restore web search tool using responses API

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A Node.js backend plugin for Omi that provides real-time AI chat capabilities us
 
 - **Voice Activation**: Listens for transcripts starting with "hey omi"
 - **Responses + Conversations**: Uses OpenAI's Responses API with Conversations for per-session context
+- **Web Search Tool**: Enables built-in `web_search` via Responses API tools for current info
 - **Real-time Notifications**: Sends responses back to users through Omi's notification API
 - **Error Handling**: Comprehensive error handling and logging
 - **Health Monitoring**: Built-in health check endpoint
@@ -36,10 +37,11 @@ Copy the environment template and configure your API keys:
 cp env.example .env
 ```
 
-Edit `.env` with your actual API keys:
+Edit `.env` with your actual API keys (prefer `OPENAI_API_KEY`; `OPENAI_KEY` is still supported):
 
 ```env
-OPENAI_KEY=sk-your-openai-api-key-here
+OPENAI_API_KEY=sk-your-openai-api-key-here
+OPENAI_KEY=
 OMI_APP_ID=your_omi_app_id_here
 OMI_APP_SECRET=your_omi_app_secret_here
 PORT=3000
@@ -103,7 +105,7 @@ railway init
 ### 4. Set Environment Variables
 
 ```bash
-railway variables set OPENAI_KEY=sk-your-openai-api-key-here
+railway variables set OPENAI_API_KEY=sk-your-openai-api-key-here
 railway variables set OMI_APP_ID=your_omi_app_id_here
 railway variables set OMI_APP_SECRET=your_omi_app_secret_here
 ```
@@ -206,11 +208,10 @@ The plugin provides comprehensive logging:
 
 ### OpenAI Configuration
 
-The plugin uses these GPT-4 settings:
-- **Model**: `gpt-4`
-- **Max Tokens**: 500
-- **Temperature**: 0.7
-- **System Prompt**: "You are a helpful AI assistant. Provide clear, concise, and helpful responses."
+The plugin uses OpenAI Responses API with Conversations:
+- **Model**: `gpt-5-mini-2025-08-07` (configurable via code)
+- **Tools**: `web_search` enabled with `tool_choice: 'auto'`
+- **Environment variable**: prefer `OPENAI_API_KEY`; `OPENAI_KEY` is also read
 
 ### Omi API Configuration
 

--- a/env.example
+++ b/env.example
@@ -1,5 +1,7 @@
 # OpenAI API Configuration
-OPENAI_KEY=your_openai_api_key_here
+# Prefer OPENAI_API_KEY (SDK default); OPENAI_KEY is still supported
+OPENAI_API_KEY=your_openai_api_key_here
+OPENAI_KEY=
 
 # Omi API Configuration (Updated)
 OMI_APP_ID=your_omi_app_id_here

--- a/server.js
+++ b/server.js
@@ -214,7 +214,8 @@ app.get('/health', (req, res) => {
     api: {
       type: 'OpenAI Responses API',
       model: OPENAI_MODEL,
-      conversation_state: 'enabled (server-managed conversation id per Omi session)'
+      conversation_state: 'enabled (server-managed conversation id per Omi session)',
+      tools: ['web_search']
     }
   });
 });
@@ -445,6 +446,10 @@ app.post('/omi-webhook', async (req, res) => {
         const requestPayload = {
           model: OPENAI_MODEL,
           input: question,
+          tools: [
+            { type: 'web_search' }
+          ],
+          tool_choice: 'auto'
         };
         if (conversationId) {
           requestPayload.conversation = conversationId;


### PR DESCRIPTION
Re-enable the `web_search` tool using the OpenAI Responses API, restoring a previously removed feature.

---
<a href="https://cursor.com/background-agent?bcId=bc-2c66f6e5-6f79-491a-babc-1bbe9187542f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2c66f6e5-6f79-491a-babc-1bbe9187542f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

