### PR TITLE
Add follow-up question catcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ OPENAI_KEY=
 OMI_APP_ID=your_omi_app_id_here
 OMI_APP_SECRET=your_omi_app_secret_here
 PORT=3000
+FOLLOW_UP_WINDOW_MS=60000
 ```
 
 ### 3. Run Locally
@@ -212,6 +213,12 @@ The plugin uses OpenAI Responses API with Conversations:
 - **Model**: `gpt-5-mini-2025-08-07` (configurable via code)
 - **Tools**: `web_search` enabled with `tool_choice: 'auto'`
 - **Environment variable**: prefer `OPENAI_API_KEY`; `OPENAI_KEY` is also read
+
+### Follow-up Detection
+
+- **Purpose**: After the AI replies, the server opens a short window to capture natural follow-ups without requiring trigger phrases.
+- **Config**: `FOLLOW_UP_WINDOW_MS` (default 60000) controls the window duration.
+- **Behavior**: During the window, short questions or phrases like "tell me more", "what about …?" are treated as follow-ups. Polite acknowledgements (e.g., "thanks", "ok") end the window.
 
 ### Omi API Configuration
 

--- a/env.example
+++ b/env.example
@@ -9,3 +9,4 @@ OMI_APP_SECRET=your_omi_app_secret_here
 
 # Server Configuration (optional - defaults to 3000)
 PORT=3000
+FOLLOW_UP_WINDOW_MS=60000


### PR DESCRIPTION
Implement a post-AI-response follow-up window to allow users to naturally ask for more information without trigger phrases.

---
<a href="https://cursor.com/background-agent?bcId=bc-3989b838-330b-4883-aa15-cfb00a64b585">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3989b838-330b-4883-aa15-cfb00a64b585">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

