### PR TITLE
Fix nanoid esm require error

### DIFF
--- a/server.js
+++ b/server.js
@@ -4,7 +4,7 @@ const OpenAI = require('openai');
 require('dotenv').config();
 const cookieParser = require('cookie-parser');
 const argon2 = require('argon2');
-const { nanoid } = require('nanoid');
+ 
 const ENABLE_USER_SYSTEM = String(process.env.ENABLE_USER_SYSTEM || 'false').toLowerCase() === 'true';
 let prisma = null;
 if (ENABLE_USER_SYSTEM) {
@@ -311,6 +311,7 @@ function getCookieOptions() {
 }
 
 async function createSession(prismaClient, userId) {
+  const { nanoid } = await import('nanoid');
   const token = nanoid(64);
   const expiresAt = new Date(Date.now() + (30 * 24 * 60 * 60 * 1000));
   await prismaClient.authSession.create({


### PR DESCRIPTION
Change `nanoid` import to dynamic `import()` within `createSession` to resolve `ERR_REQUIRE_ESM`.

---
<a href="https://cursor.com/background-agent?bcId=bc-36745cef-8705-439e-8681-d81fb16587af">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-36745cef-8705-439e-8681-d81fb16587af">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

