### PR TITLE
Enable and implement user authentication system

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -72,6 +72,8 @@ model OmiUserLink {
   omiUserId         String   @unique
   isVerified        Boolean  @default(false)
   verificationCode  String?
+  verificationExpiresAt DateTime?
+  verificationAttempts  Int      @default(0)
   verifiedAt        DateTime?
   createdAt         DateTime @default(now())
 
@@ -112,6 +114,7 @@ model Conversation {
   @@index([userId])
   @@index([omiSessionId])
   @@index([openaiConversationId])
+  @@unique([omiSessionId, openaiConversationId])
 }
 
 model Message {


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Implement OMI linking with OTP and webhook persistence for sessions, segments, conversations, and messages to enable the user system and store interaction data.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
This PR combines the planned PR 3 (OMI linking) and PR 4 (Webhook persistence). It adds API endpoints for OMI linking and confirmation, integrates voice OTP verification into the webhook, and persists OMI sessions, transcript segments, conversations, and user/assistant messages from the webhook. The webhook's verification logic was adjusted to use the `session_id` for linking.

---
<a href="https://cursor.com/background-agent?bcId=bc-3af8cf06-f0fb-4da6-839a-26d821046879">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3af8cf06-f0fb-4da6-839a-26d821046879">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

