### PR TITLE
Fix app initialization error

### DIFF
--- a/server.js
+++ b/server.js
@@ -18,6 +18,16 @@ if (ENABLE_USER_SYSTEM) {
   }
 }
 
+const app = express();
+const PORT = process.env.PORT || 3000;
+
+// Global middleware (must be registered before routes)
+app.use(express.json());
+app.use(express.urlencoded({ extended: true }));
+if (ENABLE_USER_SYSTEM) {
+  app.use(cookieParser(process.env.SESSION_SECRET || ''));
+}
+
 // --------- Typed messaging + read APIs (feature-flagged) ---------
 if (ENABLE_USER_SYSTEM) {
   // Send a user message; create/use conversation by id or by slot
@@ -236,8 +246,7 @@ if (ENABLE_USER_SYSTEM) {
  * - "keywords", "trigger words", "how to talk to you"
  */
 
-const app = express();
-const PORT = process.env.PORT || 3000;
+// duplicate initialization removed
 
 // Session storage to accumulate transcript segments
 const sessionTranscripts = new Map();
@@ -480,12 +489,7 @@ function getRateLimitStatus(userId) {
 
 // Conversation state is managed via OpenAI Conversations API per session
 
-// Middleware
-app.use(express.json());
-app.use(express.urlencoded({ extended: true }));
-if (ENABLE_USER_SYSTEM) {
-  app.use(cookieParser(process.env.SESSION_SECRET || ''));
-}
+// (moved to top) Global middleware
 
 // --------- Auth helpers (feature-flagged) ---------
 function getCookieOptions() {

--- a/server.out
+++ b/server.out
@@ -1,0 +1,23 @@
+nohup: ignoring input
+node:internal/modules/cjs/loader:1404
+  throw err;
+  ^
+
+Error: Cannot find module 'express'
+Require stack:
+- /workspace/server.js
+    at Function._resolveFilename (node:internal/modules/cjs/loader:1401:15)
+    at defaultResolveImpl (node:internal/modules/cjs/loader:1057:19)
+    at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1062:22)
+    at Function._load (node:internal/modules/cjs/loader:1211:37)
+    at TracingChannel.traceSync (node:diagnostics_channel:322:14)
+    at wrapModuleLoad (node:internal/modules/cjs/loader:235:24)
+    at Module.require (node:internal/modules/cjs/loader:1487:12)
+    at require (node:internal/modules/helpers:135:16)
+    at Object.<anonymous> (/workspace/server.js:1:17)
+    at Module._compile (node:internal/modules/cjs/loader:1730:14) {
+  code: 'MODULE_NOT_FOUND',
+  requireStack: [ '/workspace/server.js' ]
+}
+
+Node.js v22.16.0


### PR DESCRIPTION
Move Express app initialization and global middleware to the top of `server.js` and remove duplicates to resolve `ReferenceError: Cannot access 'app' before initialization`.

The `app` variable was being accessed by route definitions before it was initialized, and `app` and its global middleware were declared multiple times. This PR ensures `app` is initialized once at the top of the file before any routes, and global middleware is applied correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-348a965b-c424-486c-83df-be152ef7d28a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-348a965b-c424-486c-83df-be152ef7d28a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

