### PR TITLE
Fix expo app login and registration flow

### DIFF
--- a/mobile/app/(auth)/sign-in.tsx
+++ b/mobile/app/(auth)/sign-in.tsx
@@ -2,10 +2,11 @@ import React, { useState } from 'react';
 import { StyleSheet, View, TextInput, Button, Alert } from 'react-native';
 import { ThemedView, ThemedText } from '@/components/Themed';
 import { useAuth } from '@/contexts/AuthContext';
-import { Redirect, Link } from 'expo-router';
+import { Redirect, Link, useRouter } from 'expo-router';
 
 export default function SignInScreen() {
   const { status, login } = useAuth();
+  const router = useRouter();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [loading, setLoading] = useState(false);
@@ -17,7 +18,12 @@ export default function SignInScreen() {
     setLoading(true);
     const ok = await login(email, password);
     setLoading(false);
-    if (!ok) Alert.alert('Sign in failed');
+    if (!ok) {
+      Alert.alert('Sign in failed');
+      return;
+    }
+    // Ensure immediate navigation to the authenticated tabs
+    router.replace('/(tabs)');
   }
 
   return (

--- a/mobile/app/(auth)/sign-up.tsx
+++ b/mobile/app/(auth)/sign-up.tsx
@@ -2,10 +2,11 @@ import React, { useState } from 'react';
 import { StyleSheet, View, TextInput, Button, Alert } from 'react-native';
 import { ThemedView, ThemedText } from '@/components/Themed';
 import { useAuth } from '@/contexts/AuthContext';
-import { Redirect, Link } from 'expo-router';
+import { Redirect, Link, useRouter } from 'expo-router';
 
 export default function SignUpScreen() {
   const { status, register } = useAuth();
+  const router = useRouter();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [displayName, setDisplayName] = useState('');
@@ -18,7 +19,12 @@ export default function SignUpScreen() {
     setLoading(true);
     const ok = await register(email, password, displayName || undefined);
     setLoading(false);
-    if (!ok) Alert.alert('Sign up failed');
+    if (!ok) {
+      Alert.alert('Sign up failed');
+      return;
+    }
+    // Ensure immediate navigation to the authenticated tabs
+    router.replace('/(tabs)');
   }
 
   return (

--- a/mobile/contexts/AuthContext.tsx
+++ b/mobile/contexts/AuthContext.tsx
@@ -1,4 +1,5 @@
 import React, { createContext, useContext, useEffect, useMemo, useState } from 'react';
+import { router } from 'expo-router';
 import { Alert } from 'react-native';
 import {
   apiLogin,
@@ -104,6 +105,8 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
     } catch {}
     setUser(null);
     setStatus('unauthenticated');
+    // Navigate to auth stack after logout
+    try { router.replace('/(auth)'); } catch {}
   }
 
   async function refresh(): Promise<void> {


### PR DESCRIPTION
Add explicit `router.replace` calls after authentication actions to ensure immediate UI navigation.

The existing Expo Router `<Redirect>` components sometimes didn't trigger a UI update quickly enough after a successful login or registration, causing the app to appear unresponsive. By programmatically calling `router.replace('/(tabs)')` after login/register and `router.replace('/(auth)')` after logout, we guarantee an instant transition to the correct screen, improving user experience.

---
<a href="https://cursor.com/background-agent?bcId=bc-a7b9f466-4912-4d4b-bfa5-54cdc43efebc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a7b9f466-4912-4d4b-bfa5-54cdc43efebc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

