### PR TITLE
Fix web login, add scroll and sign out

### DIFF
--- a/mobile/app/(tabs)/control.tsx
+++ b/mobile/app/(tabs)/control.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { StyleSheet, View, Text, Button, TextInput, Alert } from 'react-native';
+import { StyleSheet, View, Text, Button, TextInput, Alert, ScrollView } from 'react-native';
 import { ThemedView, ThemedText } from '@/components/Themed';
 import { createApiClient } from '@/lib/api';
 
@@ -23,18 +23,20 @@ export default function ControlScreen() {
 
   return (
     <ThemedView style={styles.container}>
-      <ThemedText type="title">Control</ThemedText>
-      <View style={styles.row}>
-        <Text>Slot (1-5)</Text>
-        <TextInput style={styles.input} value={slot} onChangeText={setSlot} keyboardType="number-pad" />
-      </View>
-      <View style={styles.row}>
-        <Text>Message</Text>
-        <TextInput style={[styles.input, { height: 80 }]} value={text} onChangeText={setText} multiline placeholder="Type a message to the assistant" />
-      </View>
-      <Button title="Send" onPress={send} />
-      <ThemedText type="subtitle">Assistant Response</ThemedText>
-      <Text selectable>{response}</Text>
+      <ScrollView contentContainerStyle={{ paddingBottom: 24 }}>
+        <ThemedText type="title">Control</ThemedText>
+        <View style={styles.row}>
+          <Text>Slot (1-5)</Text>
+          <TextInput style={styles.input} value={slot} onChangeText={setSlot} keyboardType="number-pad" />
+        </View>
+        <View style={styles.row}>
+          <Text>Message</Text>
+          <TextInput style={[styles.input, { height: 80 }]} value={text} onChangeText={setText} multiline placeholder="Type a message to the assistant" />
+        </View>
+        <Button title="Send" onPress={send} />
+        <ThemedText type="subtitle">Assistant Response</ThemedText>
+        <Text selectable>{response}</Text>
+      </ScrollView>
     </ThemedView>
   );
 }

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { StyleSheet, View, Text, Button, ActivityIndicator, TouchableOpacity } from 'react-native';
+import { StyleSheet, View, Text, Button, ActivityIndicator, TouchableOpacity, ScrollView } from 'react-native';
 import { ThemedView, ThemedText } from '@/components/Themed';
 import { apiMe } from '@/lib/api';
 import { useAuth } from '@/contexts/AuthContext';
@@ -24,27 +24,29 @@ export default function TabOneScreen() {
 
   return (
     <ThemedView style={styles.container}>
-      <ThemedText type="title">Dashboard</ThemedText>
-      <ThemedText>Welcome{user?.displayName ? `, ${user.displayName}` : ''}!</ThemedText>
-      <View style={styles.row}>
-        <Card title="Spaces" href="/(tabs)/spaces" description="Switch spaces and windows" />
-        <Card title="Tasks" href="/(tabs)/tasks" description="Create and view tasks" />
-      </View>
-      <View style={styles.row}>
-        <Card title="Memories" href="/(tabs)/memories" description="Save and browse memories" />
-        <Card title="Control" href="/(tabs)/control" description="Send messages to assistant" />
-      </View>
-      <View style={styles.rowSingle}>
-        <Card title="Settings" href="/(tabs)/settings" description="Manage Omi link and account" />
-      </View>
-      <View style={styles.section}>
-        <View style={styles.headerRow}>
-          <ThemedText type="subtitle">Profile</ThemedText>
-          <Button title={loading ? 'Loading…' : 'Refresh'} onPress={refresh} />
+      <ScrollView contentContainerStyle={{ paddingBottom: 24 }}>
+        <ThemedText type="title">Dashboard</ThemedText>
+        <ThemedText>Welcome{user?.displayName ? `, ${user.displayName}` : ''}!</ThemedText>
+        <View style={styles.row}>
+          <Card title="Spaces" href="/(tabs)/spaces" description="Switch spaces and windows" />
+          <Card title="Tasks" href="/(tabs)/tasks" description="Create and view tasks" />
         </View>
-        {status === 'loading' || loading ? <ActivityIndicator /> : null}
-        <Text selectable>{JSON.stringify(me?.user || user, null, 2)}</Text>
-      </View>
+        <View style={styles.row}>
+          <Card title="Memories" href="/(tabs)/memories" description="Save and browse memories" />
+          <Card title="Control" href="/(tabs)/control" description="Send messages to assistant" />
+        </View>
+        <View style={styles.rowSingle}>
+          <Card title="Settings" href="/(tabs)/settings" description="Manage Omi link and account" />
+        </View>
+        <View style={styles.section}>
+          <View style={styles.headerRow}>
+            <ThemedText type="subtitle">Profile</ThemedText>
+            <Button title={loading ? 'Loading…' : 'Refresh'} onPress={refresh} />
+          </View>
+          {status === 'loading' || loading ? <ActivityIndicator /> : null}
+          <Text selectable>{JSON.stringify(me?.user || user, null, 2)}</Text>
+        </View>
+      </ScrollView>
     </ThemedView>
   );
 }

--- a/mobile/app/(tabs)/settings.tsx
+++ b/mobile/app/(tabs)/settings.tsx
@@ -1,9 +1,11 @@
 import React, { useState } from 'react';
-import { StyleSheet, View, Text, Button, TextInput, Alert } from 'react-native';
+import { StyleSheet, View, Text, Button, TextInput, Alert, ScrollView } from 'react-native';
 import { ThemedView, ThemedText } from '@/components/Themed';
 import { apiMe, apiStartOmiLink, apiConfirmOmiLink } from '@/lib/api';
+import { useAuth } from '@/contexts/AuthContext';
 
 export default function SettingsScreen() {
+  const { logout } = useAuth();
   const [omiUserId, setOmiUserId] = useState<string>('');
   const [code, setCode] = useState<string>('');
   const [me, setMe] = useState<any>(null);
@@ -42,22 +44,25 @@ export default function SettingsScreen() {
 
   return (
     <ThemedView style={styles.container}>
-      <ThemedText type="title">Settings</ThemedText>
-      <Button title="Refresh Profile" onPress={refreshProfile} />
-      <Text selectable>{JSON.stringify(me, null, 2)}</Text>
-      <View style={{ height: 16 }} />
-      <ThemedText type="subtitle">Link Omi Account</ThemedText>
-      <View style={styles.row}>
-        <Text>Omi User ID</Text>
-        <TextInput style={styles.input} value={omiUserId} onChangeText={setOmiUserId} placeholder="omi_user_id" />
-      </View>
-      <Button title="Start Linking" onPress={startLink} />
-      {devCode ? <Text selectable>Dev Code: {devCode}</Text> : null}
-      <View style={styles.row}>
-        <Text>Verification Code</Text>
-        <TextInput style={styles.input} value={code} onChangeText={setCode} placeholder="123456" />
-      </View>
-      <Button title="Confirm Code" onPress={confirmLink} />
+      <ScrollView contentContainerStyle={{ paddingBottom: 24 }}>
+        <ThemedText type="title">Settings</ThemedText>
+        <Button title="Sign out" onPress={logout} />
+        <Button title="Refresh Profile" onPress={refreshProfile} />
+        <Text selectable>{JSON.stringify(me, null, 2)}</Text>
+        <View style={{ height: 16 }} />
+        <ThemedText type="subtitle">Link Omi Account</ThemedText>
+        <View style={styles.row}>
+          <Text>Omi User ID</Text>
+          <TextInput style={styles.input} value={omiUserId} onChangeText={setOmiUserId} placeholder="omi_user_id" />
+        </View>
+        <Button title="Start Linking" onPress={startLink} />
+        {devCode ? <Text selectable>Dev Code: {devCode}</Text> : null}
+        <View style={styles.row}>
+          <Text>Verification Code</Text>
+          <TextInput style={styles.input} value={code} onChangeText={setCode} placeholder="123456" />
+        </View>
+        <Button title="Confirm Code" onPress={confirmLink} />
+      </ScrollView>
     </ThemedView>
   );
 }

--- a/mobile/app/(tabs)/spaces.tsx
+++ b/mobile/app/(tabs)/spaces.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from 'react';
-import { StyleSheet, View, Text, Button, Alert, TouchableOpacity, ActivityIndicator } from 'react-native';
+import { StyleSheet, View, Text, Button, Alert, TouchableOpacity, ActivityIndicator, ScrollView } from 'react-native';
 import { ThemedView, ThemedText } from '@/components/Themed';
 import { apiGetSpaces, apiSwitchSpace, apiListWindows, apiActivateWindow } from '@/lib/api';
 
@@ -46,27 +46,29 @@ export default function SpacesScreen() {
 
   return (
     <ThemedView style={styles.container}>
-      <View style={styles.headerRow}>
-        <ThemedText type="title">Spaces</ThemedText>
-        <Button title="Refresh" onPress={refresh} />
-      </View>
-      {loading ? <ActivityIndicator /> : null}
-      <View style={styles.badgeRow}>
-        {spaces.map((s: string) => (
-          <TouchableOpacity key={s} style={[styles.badge, activeSpace === s && styles.badgeActive]} onPress={() => onSwitchSpace(s)}>
-            <Text style={[styles.badgeText, activeSpace === s && styles.badgeTextActive]}>{s}</Text>
-          </TouchableOpacity>
-        ))}
-      </View>
-      <View style={styles.section}>
-        <ThemedText type="subtitle">Conversation Windows</ThemedText>
-        {windows.map((w: { slot: number; isActive: boolean; title?: string | null; summary?: string | null }) => (
-          <TouchableOpacity key={w.slot} style={[styles.windowItem, w.isActive && styles.windowItemActive]} onPress={() => onActivateWindow(w.slot)}>
-            <Text style={styles.windowTitle}>{w.slot}) {w.title || '<empty>'}</Text>
-            {w.summary ? <Text style={styles.windowSummary}>{w.summary}</Text> : null}
-          </TouchableOpacity>
-        ))}
-      </View>
+      <ScrollView contentContainerStyle={{ paddingBottom: 24 }}>
+        <View style={styles.headerRow}>
+          <ThemedText type="title">Spaces</ThemedText>
+          <Button title="Refresh" onPress={refresh} />
+        </View>
+        {loading ? <ActivityIndicator /> : null}
+        <View style={styles.badgeRow}>
+          {spaces.map((s: string) => (
+            <TouchableOpacity key={s} style={[styles.badge, activeSpace === s && styles.badgeActive]} onPress={() => onSwitchSpace(s)}>
+              <Text style={[styles.badgeText, activeSpace === s && styles.badgeTextActive]}>{s}</Text>
+            </TouchableOpacity>
+          ))}
+        </View>
+        <View style={styles.section}>
+          <ThemedText type="subtitle">Conversation Windows</ThemedText>
+          {windows.map((w: { slot: number; isActive: boolean; title?: string | null; summary?: string | null }) => (
+            <TouchableOpacity key={w.slot} style={[styles.windowItem, w.isActive && styles.windowItemActive]} onPress={() => onActivateWindow(w.slot)}>
+              <Text style={styles.windowTitle}>{w.slot}) {w.title || '<empty>'}</Text>
+              {w.summary ? <Text style={styles.windowSummary}>{w.summary}</Text> : null}
+            </TouchableOpacity>
+          ))}
+        </View>
+      </ScrollView>
     </ThemedView>
   );
 }


### PR DESCRIPTION
Implement web-safe session token storage, add sign-out functionality, and make tab screens scrollable.

Web login was failing because `expo-secure-store` does not work on the web, preventing session token persistence. This PR adds a `localStorage` fallback for web. It also adds a sign-out button to the Settings screen and wraps content in `ScrollView` for Home, Spaces, and Control screens to allow scrolling above the tab bar.

---
<a href="https://cursor.com/background-agent?bcId=bc-2e4149f9-067d-46dc-b274-d754a6cb7116">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2e4149f9-067d-46dc-b274-d754a6cb7116">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

