### PR TITLE
Fix user preference table errors and chat display

### DIFF
--- a/mobile/app/(tabs)/control.tsx
+++ b/mobile/app/(tabs)/control.tsx
@@ -232,6 +232,20 @@ export default function ChatScreen() {
           keyExtractor={(c: ConversationItem) => c.id}
         />
       )}
+      {selectedId ? (
+        <View style={{ padding: 12, gap: 4 }}>
+          {(() => {
+            const meta = convos.items.find((c: ConversationItem) => c.id === selectedId);
+            if (!meta) return null as any;
+            return (
+              <>
+                {meta.omiSessionKey ? <Text style={{ color: '#666', fontSize: 12 }}>OMI session: {meta.omiSessionKey}</Text> : null}
+                {meta.openaiConversationId ? <Text style={{ color: '#666', fontSize: 12 }}>OpenAI conv: {meta.openaiConversationId}</Text> : null}
+              </>
+            );
+          })()}
+        </View>
+      ) : null}
       <View style={{ height: 12 }} />
       {prefs ? (
         <View>
@@ -315,6 +329,16 @@ export default function ChatScreen() {
                     </TouchableOpacity>
                   ) : null}
                 </View>
+                {(() => {
+                  const meta = convos.items.find((c: ConversationItem) => c.id === selectedId);
+                  if (!meta) return null as any;
+                  return (
+                    <View style={{ paddingHorizontal: 12, paddingBottom: 10 }}>
+                      {meta.omiSessionKey ? <Text style={{ color: '#999', fontSize: 12 }}>OMI session: {meta.omiSessionKey}</Text> : null}
+                      {meta.openaiConversationId ? <Text style={{ color: '#999', fontSize: 12 }}>OpenAI conv: {meta.openaiConversationId}</Text> : null}
+                    </View>
+                  );
+                })()}
               </>
             )}
           </View>
@@ -369,6 +393,16 @@ export default function ChatScreen() {
                     <Text style={styles.sendBtnText}>{sending ? '...' : 'Send'}</Text>
                   </TouchableOpacity>
                 </View>
+                {(() => {
+                  const meta = convos.items.find((c: ConversationItem) => c.id === selectedId);
+                  if (!meta) return null as any;
+                  return (
+                    <View style={{ paddingHorizontal: 12, paddingBottom: 10 }}>
+                      {meta.omiSessionKey ? <Text style={{ color: '#999', fontSize: 12 }}>OMI session: {meta.omiSessionKey}</Text> : null}
+                      {meta.openaiConversationId ? <Text style={{ color: '#999', fontSize: 12 }}>OpenAI conv: {meta.openaiConversationId}</Text> : null}
+                    </View>
+                  );
+                })()}
               </>
             )}
           </ThemedView>
@@ -433,6 +467,16 @@ export default function ChatScreen() {
                   </TouchableOpacity>
                 ) : null}
               </View>
+              {(() => {
+                const meta = convos.items.find((c: ConversationItem) => c.id === selectedId);
+                if (!meta) return null as any;
+                return (
+                  <View style={{ paddingHorizontal: 12, paddingBottom: 10 }}>
+                    {meta.omiSessionKey ? <Text style={{ color: '#999', fontSize: 12 }}>OMI session: {meta.omiSessionKey}</Text> : null}
+                    {meta.openaiConversationId ? <Text style={{ color: '#999', fontSize: 12 }}>OpenAI conv: {meta.openaiConversationId}</Text> : null}
+                  </View>
+                );
+              })()}
             </>
           )}
         </ThemedView>

--- a/mobile/lib/api.ts
+++ b/mobile/lib/api.ts
@@ -204,7 +204,14 @@ export async function apiConfirmOmiLink(omi_user_id: string, code: string): Prom
 }
 
 // Conversations & Messages
-export type ConversationItem = { id: string; title?: string | null; summary?: string | null; createdAt: string };
+export type ConversationItem = {
+  id: string;
+  title?: string | null;
+  summary?: string | null;
+  createdAt: string;
+  openaiConversationId?: string | null;
+  omiSessionKey?: string | null;
+};
 export type MessageItem = { id: string; role: 'USER' | 'ASSISTANT' | 'SYSTEM' | 'TOOL'; text: string; source: string; createdAt: string };
 
 export async function apiListConversations(limit: number = 20, cursor?: string): Promise<{ items: ConversationItem[]; nextCursor: string | null }> {

--- a/prisma/migrations/20250113000002_add_user_preferences/migration.sql
+++ b/prisma/migrations/20250113000002_add_user_preferences/migration.sql
@@ -1,0 +1,71 @@
+-- CreateEnum if not exists for ListenMode
+DO $$ BEGIN
+  CREATE TYPE "public"."ListenMode" AS ENUM ('TRIGGER', 'FOLLOWUP', 'ALWAYS');
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+-- CreateTable UserPreference (if not exists)
+DO $$ BEGIN
+  CREATE TABLE IF NOT EXISTS "public"."UserPreference" (
+    "userId" UUID NOT NULL,
+    "listenMode" "public"."ListenMode" NOT NULL DEFAULT 'TRIGGER',
+    "followupWindowMs" INTEGER NOT NULL DEFAULT 8000,
+    "meetingTranscribe" BOOLEAN NOT NULL DEFAULT false,
+    "injectMemories" BOOLEAN NOT NULL DEFAULT false,
+    "defaultConversationId" UUID,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "UserPreference_pkey" PRIMARY KEY ("userId")
+  );
+EXCEPTION
+  WHEN duplicate_table THEN null;
+END $$;
+
+-- Add foreign key constraints for UserPreference (if not already present)
+DO $$ BEGIN
+  ALTER TABLE "public"."UserPreference"
+    ADD CONSTRAINT "UserPreference_userId_fkey"
+      FOREIGN KEY ("userId") REFERENCES "public"."User"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+DO $$ BEGIN
+  CREATE INDEX IF NOT EXISTS "UserPreference_defaultConversationId_idx"
+    ON "public"."UserPreference"("defaultConversationId");
+END $$;
+
+DO $$ BEGIN
+  ALTER TABLE "public"."UserPreference"
+    ADD CONSTRAINT "UserPreference_defaultConversationId_fkey"
+      FOREIGN KEY ("defaultConversationId") REFERENCES "public"."Conversation"("id") ON DELETE SET NULL ON UPDATE CASCADE;
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+
+-- CreateTable OmiSessionPreference (if not exists)
+DO $$ BEGIN
+  CREATE TABLE IF NOT EXISTS "public"."OmiSessionPreference" (
+    "omiSessionId" UUID NOT NULL,
+    "listenMode" "public"."ListenMode" NOT NULL DEFAULT 'TRIGGER',
+    "followupWindowMs" INTEGER NOT NULL DEFAULT 8000,
+    "meetingTranscribe" BOOLEAN NOT NULL DEFAULT false,
+    "injectMemories" BOOLEAN NOT NULL DEFAULT false,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    CONSTRAINT "OmiSessionPreference_pkey" PRIMARY KEY ("omiSessionId")
+  );
+EXCEPTION
+  WHEN duplicate_table THEN null;
+END $$;
+
+-- Add foreign key constraints for OmiSessionPreference
+DO $$ BEGIN
+  ALTER TABLE "public"."OmiSessionPreference"
+    ADD CONSTRAINT "OmiSessionPreference_omiSessionId_fkey"
+      FOREIGN KEY ("omiSessionId") REFERENCES "public"."OmiSession"("id") ON DELETE CASCADE ON UPDATE CASCADE;
+EXCEPTION
+  WHEN duplicate_object THEN null;
+END $$;
+


### PR DESCRIPTION
Add missing user preference database tables and display OMI session/OpenAI conversation IDs in the mobile chat UI.

This fixes `relation "public.UserPreference" does not exist` errors by creating the necessary tables and enum. It also addresses the user's request to see the live OMI session key and OpenAI conversation ID for the currently selected chat.

---
<a href="https://cursor.com/background-agent?bcId=bc-b79a436b-a5d5-4b41-af6d-3b60a30791b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b79a436b-a5d5-4b41-af6d-3b60a30791b5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

