### PR TITLE
Import user memories automatically and on demand

### DIFF
--- a/mobile/lib/api.ts
+++ b/mobile/lib/api.ts
@@ -416,6 +416,19 @@ export async function apiDeleteMemory(id: string): Promise<boolean> {
   }
 }
 
+// Import memories from OMI into local DB for the authenticated user
+export async function apiImportMemoriesFromOmi(options?: { pageLimit?: number; maxTotal?: number }): Promise<{ ok: boolean; imported?: number; skipped?: number } | null> {
+  const client = createApiClient();
+  try {
+    const payload: any = {};
+    if (options && typeof options.pageLimit === 'number') payload.limit = options.pageLimit;
+    if (options && typeof options.maxTotal === 'number') payload.max_total = options.maxTotal;
+    const { data } = await client.post('/memories/import/omi', payload);
+    if (data && typeof data.ok !== 'undefined') return data;
+  } catch {}
+  return null;
+}
+
 // Agent events (tasks)
 export type AgentEventItem = { id: string; type: string; payload?: any; createdAt: string };
 export async function apiListAgentEvents(limit: number = 50, cursor?: string): Promise<{ items: AgentEventItem[]; nextCursor: string | null }> {


### PR DESCRIPTION
Add a 'Sync from OMI' button and auto-import on mount to allow users to manually import all memories and automatically refresh a small batch.

---
<a href="https://cursor.com/background-agent?bcId=bc-4be0ac8b-2b47-42e1-ac0d-6ed4309c3ad5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4be0ac8b-2b47-42e1-ac0d-6ed4309c3ad5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

