### PR TITLE
Fix chat memory context not updating

### DIFF
--- a/routes/omi.js
+++ b/routes/omi.js
@@ -22,10 +22,23 @@ module.exports = function createOmiRoutes({ app, prisma, openai, OPENAI_MODEL, E
         if (up) pref = up;
       }
     }
-    const merged = {
-      ...pref,
-      ...(sessionPref || {})
-    };
+    // Merge session-level preferences without overriding user-level injectMemories
+    // Session prefs can override activation/listen behavior, but memory injection is a per-user opt-in
+    let merged = { ...pref };
+    if (sessionPref) {
+      merged = {
+        ...merged,
+        listenMode: sessionPref.listenMode,
+        followupWindowMs: sessionPref.followupWindowMs,
+        meetingTranscribe: sessionPref.meetingTranscribe,
+        // intentionally NOT overriding injectMemories here
+        activationRegex: sessionPref.activationRegex,
+        activationSensitivity: sessionPref.activationSensitivity,
+        mute: sessionPref.mute,
+        dndQuietHoursStart: sessionPref.dndQuietHoursStart,
+        dndQuietHoursEnd: sessionPref.dndQuietHoursEnd
+      };
+    }
     const regex = buildActivationRegex(merged.activationRegex);
     return { pref: merged, regex };
   }

--- a/server.js
+++ b/server.js
@@ -1914,7 +1914,7 @@ if (!ENABLE_NEW_OMI_ROUTES) app.post('/omi-webhook', async (req, res) => {
       }
     }
     
-    // Load preferences (user-linked or session-level defaults)
+    // Load preferences: prefer user-level for injectMemories; allow session to override listen/followup/transcribe
     let listenMode = 'TRIGGER';
     let followupWindowMs = 8000;
     let injectMemories = false;
@@ -1922,19 +1922,21 @@ if (!ENABLE_NEW_OMI_ROUTES) app.post('/omi-webhook', async (req, res) => {
     if (ENABLE_USER_SYSTEM && prisma) {
       try {
         const sessionRow = await prisma.omiSession.findUnique({ where: { omiSessionId: String(session_id) }, include: { user: true, preferences: true } });
-        if (sessionRow && sessionRow.preferences) {
+        let userPref = null;
+        if (sessionRow?.user) {
+          userPref = await prisma.userPreference.findUnique({ where: { userId: sessionRow.user.id } });
+        }
+        if (userPref) {
+          listenMode = userPref.listenMode;
+          followupWindowMs = userPref.followupWindowMs;
+          injectMemories = userPref.injectMemories;
+          meetingTranscribe = userPref.meetingTranscribe;
+        }
+        if (sessionRow?.preferences) {
+          // Override selected fields from session preferences, but do not override injectMemories
           listenMode = sessionRow.preferences.listenMode;
           followupWindowMs = sessionRow.preferences.followupWindowMs;
-          injectMemories = sessionRow.preferences.injectMemories;
           meetingTranscribe = sessionRow.preferences.meetingTranscribe;
-        } else if (sessionRow && sessionRow.user) {
-          const pref = await prisma.userPreference.findUnique({ where: { userId: sessionRow.user.id } });
-          if (pref) {
-            listenMode = pref.listenMode;
-            followupWindowMs = pref.followupWindowMs;
-            injectMemories = pref.injectMemories;
-            meetingTranscribe = pref.meetingTranscribe;
-          }
         }
       } catch {}
     }


### PR DESCRIPTION
Restore user's `injectMemories` preference functionality by preventing session-level overrides.

---
<a href="https://cursor.com/background-agent?bcId=bc-438bd01a-45ff-4969-9b8b-65b89b0928fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-438bd01a-45ff-4969-9b8b-65b89b0928fe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

