### PR TITLE
Fix css style declaration error in a component

### DIFF
--- a/mobile/app/(tabs)/control.tsx
+++ b/mobile/app/(tabs)/control.tsx
@@ -222,7 +222,22 @@ export default function ChatScreen() {
     const res = await apiSendMessage({ conversation_id: selectedId, text });
     setSending(false);
     if (!res) return;
-    // Refresh messages to include assistant response
+    // Remove the optimistic message to avoid duplicates, server will return canonical message
+    setMessages((prev: MessageState) => {
+      const existing = prev.byConversationId[selectedId!]?.items || [];
+      const filtered = existing.filter((m) => m.id !== optimistic.id);
+      return {
+        byConversationId: {
+          ...prev.byConversationId,
+          [selectedId!]: {
+            items: filtered,
+            nextCursor: prev.byConversationId[selectedId!]?.nextCursor || null,
+            loading: false,
+          },
+        },
+      };
+    });
+    // Refresh messages to include server message + assistant response
     await loadLatest(selectedId);
   }, [input, sending, selectedId]);
 

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -66,7 +66,7 @@ const styles = StyleSheet.create({
 function Card({ title, description, href, fullWidth }: { title: string; description: string; href: string; fullWidth?: boolean }) {
   return (
     <Link href={href} asChild>
-      <TouchableOpacity style={[cardStyles.card, fullWidth && { flexBasis: '100%' }]}>
+      <TouchableOpacity style={StyleSheet.flatten([cardStyles.card, fullWidth && { flexBasis: '100%' }])}>
         <Text style={cardStyles.title}>{title}</Text>
         <Text style={cardStyles.desc}>{description}</Text>
       </TouchableOpacity>


### PR DESCRIPTION
Fixes web `<a>` style error by flattening style array and prevents duplicate chat messages by removing optimistic message before refreshing.

The web style error occurs because React Native for Web renders `TouchableOpacity` as an `<a>` tag, and directly passing a style array to a DOM element's `style` prop is not supported. `StyleSheet.flatten` resolves this by converting the array into a single style object. For the chat, the optimistic message was not removed before the server's response was fetched, causing it to appear twice.

---
<a href="https://cursor.com/background-agent?bcId=bc-4a55b504-3594-4c60-9f92-b177e9491f3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-4a55b504-3594-4c60-9f92-b177e9491f3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

