### PR TITLE
Handle concurrent memory + transcript payloads

### DIFF
--- a/routes/omi.js
+++ b/routes/omi.js
@@ -106,6 +106,8 @@ module.exports = function createOmiRoutes({ app, prisma, openai, OPENAI_MODEL, E
         }
       }
 
+      let sessionRowId = null;
+
       async function persistMemoryPayload(payload) {
         if (!(ENABLE_USER_SYSTEM && prisma)) {
           throw new Error('User system disabled');
@@ -132,6 +134,67 @@ module.exports = function createOmiRoutes({ app, prisma, openai, OPENAI_MODEL, E
         }
         const saved = await prisma.memory.create({ data: { userId, text: memText } });
         return { status: 201, body: { ok: true, memory: { id: saved.id, text: saved.text, createdAt: saved.createdAt } } };
+      }
+
+      async function ensureSessionRow(extraUpdate = {}) {
+        if (!(ENABLE_USER_SYSTEM && prisma)) return null;
+        const update = { lastSeenAt: new Date() };
+        const create = { omiSessionId: String(session_id), lastSeenAt: new Date() };
+        if (linkedUserId) {
+          update.userId = linkedUserId;
+          create.userId = linkedUserId;
+        }
+        for (const [key, value] of Object.entries(extraUpdate || {})) {
+          if (typeof value === 'undefined') continue;
+          update[key] = value;
+          create[key] = value;
+        }
+        const sessionRow = await prisma.omiSession.upsert({
+          where: { omiSessionId: String(session_id) },
+          update,
+          create
+        });
+        sessionRowCache = sessionRow;
+        sessionRowId = sessionRow?.id || sessionRowId;
+        return sessionRow;
+      }
+
+      async function persistTranscriptSegments(sessionIdForSegments, segmentsToPersist) {
+        if (!(ENABLE_USER_SYSTEM && prisma)) return;
+        if (!sessionIdForSegments || !Array.isArray(segmentsToPersist) || !segmentsToPersist.length) return;
+        const operations = segmentsToPersist
+          .map((seg) => {
+            if (!seg) return null;
+            const text = String(seg.text || '');
+            const omiSegmentId = String(seg.id || seg.segment_id || crypto.createHash('sha1').update(text).digest('hex'));
+            return prisma.transcriptSegment
+              .upsert({
+                where: { omiSessionId_omiSegmentId: { omiSessionId: sessionIdForSegments, omiSegmentId } },
+                update: {
+                  text,
+                  speaker: seg.speaker || null,
+                  speakerId: seg.speaker_id ?? seg.speakerId ?? null,
+                  isUser: seg.is_user ?? null,
+                  start: seg.start ?? null,
+                  end: seg.end ?? null
+                },
+                create: {
+                  omiSessionId: sessionIdForSegments,
+                  omiSegmentId,
+                  text,
+                  speaker: seg.speaker || null,
+                  speakerId: seg.speaker_id ?? seg.speakerId ?? null,
+                  isUser: seg.is_user ?? null,
+                  start: seg.start ?? null,
+                  end: seg.end ?? null
+                }
+              })
+              .catch((err) => {
+                console.error('Transcript segment upsert failed:', err);
+              });
+          })
+          .filter(Boolean);
+        await Promise.all(operations);
       }
 
       // Transcript mode (existing behavior)
@@ -199,11 +262,23 @@ module.exports = function createOmiRoutes({ app, prisma, openai, OPENAI_MODEL, E
           linkedUserId = sessionRowCache.userId;
         }
       }
+      sessionRowId = sessionRowCache?.id || sessionRowId;
 
       const { pref, regex } = await loadActivationConfig(session_id, linkedUserId, sessionRowCache);
 
-      // Meeting transcribe special mode: only persist (already done) and optionally return on end
+      // Meeting transcribe special mode: persist transcript segments immediately and optionally return on end
       if (pref.meetingTranscribe) {
+        if (ENABLE_USER_SYSTEM && prisma) {
+          try {
+            const sessionRow = await ensureSessionRow();
+            const sessionIdForSegments = sessionRow?.id || sessionRowId;
+            if (sessionIdForSegments) {
+              await persistTranscriptSegments(sessionIdForSegments, segments);
+            }
+          } catch (err) {
+            console.error('Meeting transcript persistence failed:', err);
+          }
+        }
         const endSignal = Boolean(req.body?.end || req.body?.final || req.body?.is_final) ||
           segments.some((s) => s?.end === true || s?.final === true || s?.is_final === true || s?.is_last_segment === true || s?.segment_type === 'end');
         if (!endSignal) return res.status(200).json({});
@@ -277,22 +352,41 @@ module.exports = function createOmiRoutes({ app, prisma, openai, OPENAI_MODEL, E
       ].filter(Boolean).join('\n\n');
 
       // Ensure conversation id is stored in OmiSession
-      let conversationId = null;
-      if (ENABLE_USER_SYSTEM && prisma) {
+      let conversationId = sessionRowCache?.openaiConversationId || null;
+      if (!conversationId && ENABLE_USER_SYSTEM && prisma) {
         try {
-          const sessionRow = sessionRowCache || await prisma.omiSession.findUnique({ where: { omiSessionId: String(session_id) } });
-          if (sessionRow && !sessionRowCache) sessionRowCache = sessionRow;
-          if (sessionRow && sessionRow.openaiConversationId) {
-            conversationId = sessionRow.openaiConversationId;
+          const refreshedSession = await prisma.omiSession.findUnique({
+            where: { omiSessionId: String(session_id) },
+            select: { id: true, userId: true, openaiConversationId: true }
+          });
+          if (refreshedSession) {
+            if (refreshedSession.openaiConversationId) {
+              conversationId = refreshedSession.openaiConversationId;
+            }
+            sessionRowId = refreshedSession.id || sessionRowId;
+            sessionRowCache = sessionRowCache ? { ...sessionRowCache, ...refreshedSession } : refreshedSession;
           }
-        } catch {}
+        } catch (err) {
+          console.error('Session refresh failed:', err);
+        }
       }
       if (!conversationId) {
         try {
           const conversation = await openai.conversations.create({ metadata: { omi_session_id: String(session_id) } });
           conversationId = conversation.id;
-          if (sessionRowCache) sessionRowCache.openaiConversationId = conversationId;
-        } catch {}
+        } catch (err) {
+          console.error('OpenAI conversation create failed:', err);
+        }
+      }
+      if (ENABLE_USER_SYSTEM && prisma) {
+        try {
+          const sessionRow = await ensureSessionRow(conversationId ? { openaiConversationId: conversationId } : {});
+          if (sessionRow?.openaiConversationId) {
+            conversationId = sessionRow.openaiConversationId;
+          }
+        } catch (err) {
+          console.error('Session metadata persistence failed:', err);
+        }
       }
 
       // Call OpenAI
@@ -327,55 +421,41 @@ module.exports = function createOmiRoutes({ app, prisma, openai, OPENAI_MODEL, E
       if (ENABLE_USER_SYSTEM && prisma) {
         const backgroundSessionId = String(session_id);
         const backgroundSegments = Array.isArray(segments) ? segments.slice() : [];
-        const backgroundLinkedUserId = linkedUserId;
         const backgroundConversationId = conversationId ? String(conversationId) : null;
         const backgroundQuestion = question;
         const backgroundAiResponse = aiResponse;
+        const backgroundSessionRowId = sessionRowId;
+        const backgroundUserId = sessionRowCache?.userId || linkedUserId || null;
         setImmediate(async () => {
           try {
-            const sessionUpdate = { lastSeenAt: new Date() };
-            const sessionCreate = { omiSessionId: backgroundSessionId };
-            if (backgroundLinkedUserId) {
-              sessionUpdate.userId = backgroundLinkedUserId;
-              sessionCreate.userId = backgroundLinkedUserId;
-            }
-            if (backgroundConversationId) {
-              sessionUpdate.openaiConversationId = backgroundConversationId;
-              sessionCreate.openaiConversationId = backgroundConversationId;
-            }
-            const sessionRow = await prisma.omiSession.upsert({
-              where: { omiSessionId: backgroundSessionId },
-              update: sessionUpdate,
-              create: sessionCreate
-            });
-            const sessionRowId = sessionRow?.id;
+            let effectiveSessionRowId = backgroundSessionRowId;
+            let effectiveUserId = backgroundUserId;
 
-            if (sessionRowId && backgroundSegments.length) {
+            if (!effectiveSessionRowId) {
               try {
-                const operations = backgroundSegments.map((seg) => {
-                  if (!seg) return Promise.resolve();
-                  const text = String(seg.text || '');
-                  const omiSegmentId = String(seg.id || seg.segment_id || crypto.createHash('sha1').update(text).digest('hex'));
-                  return prisma.transcriptSegment.upsert({
-                    where: { omiSessionId_omiSegmentId: { omiSessionId: sessionRowId, omiSegmentId } },
-                    update: { text, speaker: seg.speaker || null, speakerId: (seg.speaker_id ?? seg.speakerId ?? null), isUser: seg.is_user ?? null, start: seg.start ?? null, end: seg.end ?? null },
-                    create: { omiSessionId: sessionRowId, omiSegmentId, text, speaker: seg.speaker || null, speakerId: (seg.speaker_id ?? seg.speakerId ?? null), isUser: seg.is_user ?? null, start: seg.start ?? null, end: seg.end ?? null }
-                  }).catch((err) => {
-                    console.error('Transcript segment upsert failed:', err);
-                  });
+                const refreshed = await prisma.omiSession.findUnique({
+                  where: { omiSessionId: backgroundSessionId },
+                  select: { id: true, userId: true }
                 });
-                await Promise.all(operations);
+                if (refreshed) {
+                  effectiveSessionRowId = refreshed.id;
+                  if (refreshed.userId) effectiveUserId = refreshed.userId;
+                }
               } catch (err) {
-                console.error('Background transcript persistence failed:', err);
+                console.error('Background session lookup failed:', err);
               }
             }
 
-            if (sessionRowId && backgroundConversationId) {
+            if (effectiveSessionRowId && backgroundSegments.length) {
+              await persistTranscriptSegments(effectiveSessionRowId, backgroundSegments);
+            }
+
+            if (effectiveSessionRowId && backgroundConversationId) {
               try {
                 const conversationRow = await prisma.conversation.upsert({
-                  where: { omiSessionId_openaiConversationId: { omiSessionId: sessionRowId, openaiConversationId: backgroundConversationId } },
+                  where: { omiSessionId_openaiConversationId: { omiSessionId: effectiveSessionRowId, openaiConversationId: backgroundConversationId } },
                   update: {},
-                  create: { omiSessionId: sessionRowId, openaiConversationId: backgroundConversationId }
+                  create: { omiSessionId: effectiveSessionRowId, openaiConversationId: backgroundConversationId }
                 });
                 if (backgroundQuestion) {
                   await prisma.message.create({ data: { conversationId: conversationRow.id, role: 'USER', text: backgroundQuestion, source: 'OMI_TRANSCRIPT' } });
@@ -383,18 +463,28 @@ module.exports = function createOmiRoutes({ app, prisma, openai, OPENAI_MODEL, E
                 if (backgroundAiResponse) {
                   await prisma.message.create({ data: { conversationId: conversationRow.id, role: 'ASSISTANT', text: backgroundAiResponse, source: 'SYSTEM' } });
                 }
-                if (sessionRow.userId) {
-                  const userId = sessionRow.userId;
-                  let active = await prisma.userContextWindow.findFirst({ where: { userId, isActive: true } });
+                if (!effectiveUserId) {
+                  try {
+                    const refreshedUser = await prisma.omiSession.findUnique({
+                      where: { id: effectiveSessionRowId },
+                      select: { userId: true }
+                    });
+                    if (refreshedUser?.userId) effectiveUserId = refreshedUser.userId;
+                  } catch (err) {
+                    console.error('Background user lookup failed:', err);
+                  }
+                }
+                if (effectiveUserId) {
+                  let active = await prisma.userContextWindow.findFirst({ where: { userId: effectiveUserId, isActive: true } });
                   if (!active) {
-                    const existingSlot1 = await prisma.userContextWindow.findUnique({ where: { userId_slot: { userId, slot: 1 } } });
+                    const existingSlot1 = await prisma.userContextWindow.findUnique({ where: { userId_slot: { userId: effectiveUserId, slot: 1 } } });
                     if (!existingSlot1) {
-                      await prisma.userContextWindow.create({ data: { userId, slot: 1, conversationId: conversationRow.id, isActive: true } });
+                      await prisma.userContextWindow.create({ data: { userId: effectiveUserId, slot: 1, conversationId: conversationRow.id, isActive: true } });
                     } else {
-                      await prisma.userContextWindow.update({ where: { userId_slot: { userId, slot: 1 } }, data: { conversationId: conversationRow.id, isActive: true } });
+                      await prisma.userContextWindow.update({ where: { userId_slot: { userId: effectiveUserId, slot: 1 } }, data: { conversationId: conversationRow.id, isActive: true } });
                     }
                   } else {
-                    await prisma.userContextWindow.update({ where: { userId_slot: { userId, slot: active.slot } }, data: { conversationId: conversationRow.id } });
+                    await prisma.userContextWindow.update({ where: { userId_slot: { userId: effectiveUserId, slot: active.slot } }, data: { conversationId: conversationRow.id } });
                   }
                 }
               } catch (err) {
@@ -402,7 +492,7 @@ module.exports = function createOmiRoutes({ app, prisma, openai, OPENAI_MODEL, E
               }
             }
           } catch (err) {
-            console.error('Background session persistence failed:', err);
+            console.error('Background persistence failed:', err);
           }
         });
       }

--- a/routes/omi.js
+++ b/routes/omi.js
@@ -374,6 +374,7 @@ module.exports = function createOmiRoutes({ app, prisma, openai, OPENAI_MODEL, E
         try {
           const conversation = await openai.conversations.create({ metadata: { omi_session_id: String(session_id) } });
           conversationId = conversation.id;
+          if (sessionRowCache) sessionRowCache.openaiConversationId = conversationId;
         } catch (err) {
           console.error('OpenAI conversation create failed:', err);
         }

--- a/routes/omi.js
+++ b/routes/omi.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const crypto = require('crypto');
 const { buildActivationRegex, withinQuietHours, normalizeText, isNearDuplicate } = require('../services/activation');
 const { ENABLE_CONTEXT_ACTIVATION, QUIET_HOURS_ENABLED } = require('../featureFlags');
 
@@ -7,19 +8,35 @@ module.exports = function createOmiRoutes({ app, prisma, openai, OPENAI_MODEL, E
   if (!app) throw new Error('app is required');
 
   // Helper: fetch session + user preferences and derive activation config
-  async function loadActivationConfig(sessionId) {
+  async function loadActivationConfig(sessionId, overrideUserId = null, sessionRowOverride = null) {
     let pref = { listenMode: 'TRIGGER', followupWindowMs: 8000, injectMemories: false, meetingTranscribe: false };
     let sessionPref = null;
     let user = null;
     if (ENABLE_USER_SYSTEM && prisma) {
-      const sessionRow = await prisma.omiSession.findUnique({ where: { omiSessionId: String(sessionId) }, include: { user: true, preferences: true } });
+      let sessionRow = sessionRowOverride;
+      if (!sessionRow) {
+        sessionRow = await prisma.omiSession.findUnique({ where: { omiSessionId: String(sessionId) }, include: { user: true, preferences: true } });
+      }
       if (sessionRow) {
         sessionPref = sessionRow.preferences || null;
         user = sessionRow.user || null;
       }
-      if (user) {
-        const up = await prisma.userPreference.findUnique({ where: { userId: user.id } });
-        if (up) pref = up;
+      const targetUserId = overrideUserId || (user ? user.id : null);
+      if (targetUserId) {
+        if (!user || user.id !== targetUserId) {
+          try {
+            user = await prisma.user.findUnique({ where: { id: targetUserId } });
+          } catch {}
+        }
+        try {
+          const up = await prisma.userPreference.findUnique({ where: { userId: targetUserId } });
+          if (up) pref = up;
+        } catch {}
+      } else if (user) {
+        try {
+          const up = await prisma.userPreference.findUnique({ where: { userId: user.id } });
+          if (up) pref = up;
+        } catch {}
       }
     }
     const merged = {
@@ -39,7 +56,12 @@ module.exports = function createOmiRoutes({ app, prisma, openai, OPENAI_MODEL, E
       // Memory ingestion mode (payload includes full memory object and uid query)
       const uid = req.query && req.query.uid ? String(req.query.uid) : null;
       const body = req.body || {};
-      const isMemoryPayload = !!(uid && (Array.isArray(body.transcript_segments) || body.structured || typeof body.discarded !== 'undefined'));
+      const hasMemoryPayload = !!(uid && (
+        Array.isArray(body.transcript_segments) ||
+        Array.isArray(body.memory_segments) ||
+        body.structured ||
+        typeof body.discarded !== 'undefined'
+      ));
 
       async function composeMemoryText(payload) {
         try {
@@ -56,7 +78,9 @@ module.exports = function createOmiRoutes({ app, prisma, openai, OPENAI_MODEL, E
           else if (overview) text = overview;
           else if (line) text = line;
           if (!text) {
-            const segs = Array.isArray(payload.transcript_segments) ? payload.transcript_segments : [];
+            const segs = Array.isArray(payload.transcript_segments)
+              ? payload.transcript_segments
+              : (Array.isArray(payload.memory_segments) ? payload.memory_segments : []);
             if (segs.length) {
               const combined = segs
                 .map((s) => (typeof s.text === 'string' ? s.text.trim() : ''))
@@ -82,62 +106,101 @@ module.exports = function createOmiRoutes({ app, prisma, openai, OPENAI_MODEL, E
         }
       }
 
-      if (isMemoryPayload) {
-        if (!(ENABLE_USER_SYSTEM && prisma)) return res.status(503).json({ error: 'User system disabled' });
-        try {
-          if (body && body.discarded === true) return res.status(200).json({ ok: true, ignored: true, discarded: true });
-          const link = await prisma.omiUserLink.findUnique({ where: { omiUserId: uid } });
-          if (!link || !link.isVerified) return res.status(404).json({ error: 'uid not linked to a verified user' });
-          const userId = link.userId;
-          const memText = (await composeMemoryText(body)).trim();
-          if (!memText) return res.status(200).json({ ok: true, ignored: true });
-          // Deduplicate within recent window
-          const since = new Date(Date.now() - 12 * 60 * 60 * 1000);
-          const dupe = await prisma.memory.findFirst({ where: { userId, text: memText, createdAt: { gt: since } } });
-          if (dupe) {
-            return res.status(200).json({ ok: true, deduped: true, memory: { id: dupe.id, text: dupe.text, createdAt: dupe.createdAt } });
-          }
-          const saved = await prisma.memory.create({ data: { userId, text: memText } });
-          return res.status(201).json({ ok: true, memory: { id: saved.id, text: saved.text, createdAt: saved.createdAt } });
-        } catch (e) {
-          return res.status(500).json({ error: 'Failed to save memory' });
+      async function persistMemoryPayload(payload) {
+        if (!(ENABLE_USER_SYSTEM && prisma)) {
+          throw new Error('User system disabled');
         }
+        if (payload && payload.discarded === true) {
+          return { status: 200, body: { ok: true, ignored: true, discarded: true } };
+        }
+        const link = await prisma.omiUserLink.findUnique({ where: { omiUserId: uid } });
+        if (!link || !link.isVerified) {
+          return { status: 404, body: { error: 'uid not linked to a verified user' } };
+        }
+        const userId = link.userId;
+        const memText = (await composeMemoryText(payload)).trim();
+        if (!memText) {
+          return { status: 200, body: { ok: true, ignored: true } };
+        }
+        const since = new Date(Date.now() - 12 * 60 * 60 * 1000);
+        const dupe = await prisma.memory.findFirst({ where: { userId, text: memText, createdAt: { gt: since } } });
+        if (dupe) {
+          return {
+            status: 200,
+            body: { ok: true, deduped: true, memory: { id: dupe.id, text: dupe.text, createdAt: dupe.createdAt } }
+          };
+        }
+        const saved = await prisma.memory.create({ data: { userId, text: memText } });
+        return { status: 201, body: { ok: true, memory: { id: saved.id, text: saved.text, createdAt: saved.createdAt } } };
       }
 
       // Transcript mode (existing behavior)
       const session_id = (req.query && req.query.session_id ? String(req.query.session_id) : (body && body.session_id ? String(body.session_id) : null));
       const segments = Array.isArray(body) ? body : (Array.isArray(body.segments) ? body.segments : []);
-      if (!session_id || !segments.length) return res.status(400).json({ error: 'session_id and segments[] required' });
+      const hasSegments = segments.length > 0;
 
-      // Persist segments immediately for idempotency
+      if (hasMemoryPayload) {
+        if (!(ENABLE_USER_SYSTEM && prisma)) {
+          if (!hasSegments) {
+            return res.status(503).json({ error: 'User system disabled' });
+          }
+        } else if (!hasSegments) {
+          try {
+            const memoryResult = await persistMemoryPayload(body);
+            return res.status(memoryResult.status).json(memoryResult.body);
+          } catch (e) {
+            return res.status(500).json({ error: 'Failed to save memory' });
+          }
+        } else {
+          const memoryPayload = {
+            structured: body.structured,
+            overview: body.overview,
+            transcript_segments: Array.isArray(body.transcript_segments) ? body.transcript_segments : undefined,
+            memory_segments: Array.isArray(body.memory_segments) ? body.memory_segments : undefined,
+            discarded: body.discarded === true
+          };
+          setImmediate(async () => {
+            try {
+              const result = await persistMemoryPayload(memoryPayload);
+              if (result?.status >= 400) {
+                console.warn('Memory payload skipped:', result.body?.error || result.body);
+              }
+            } catch (err) {
+              console.error('Background memory persistence failed:', err);
+            }
+          });
+        }
+      }
+
+      if (!hasSegments) {
+        return res.status(400).json({ error: 'segments[] required' });
+      }
+
+      if (!session_id) return res.status(400).json({ error: 'session_id required' });
+
+      // Resolve any linked user/session metadata needed for context without blocking the response on writes.
+      let linkedUserId = null;
+      let sessionRowCache = null;
       if (ENABLE_USER_SYSTEM && prisma) {
         const payloadUserId = (req.query?.uid ? String(req.query.uid) : (req.body?.uid ? String(req.body.uid) : (req.body?.user_id ? String(req.body.user_id) : null)));
-        let linkedUserId = null;
         if (payloadUserId) {
           try {
             const link = await prisma.omiUserLink.findUnique({ where: { omiUserId: payloadUserId } });
             if (link && link.isVerified) linkedUserId = link.userId;
           } catch {}
         }
-        const sessionRow = await prisma.omiSession.upsert({
-          where: { omiSessionId: String(session_id) },
-          update: { lastSeenAt: new Date(), ...(linkedUserId ? { userId: linkedUserId } : {}) },
-          create: { omiSessionId: String(session_id), ...(linkedUserId ? { userId: linkedUserId } : {}) }
-        });
-        for (const seg of segments) {
-          const text = String(seg.text || '');
-          const omiSegmentId = String(seg.id || seg.segment_id || require('crypto').createHash('sha1').update(text).digest('hex'));
-          try {
-            await prisma.transcriptSegment.upsert({
-              where: { omiSessionId_omiSegmentId: { omiSessionId: sessionRow.id, omiSegmentId } },
-              update: { text, speaker: seg.speaker || null, speakerId: (seg.speaker_id ?? seg.speakerId ?? null), isUser: seg.is_user ?? null, start: seg.start ?? null, end: seg.end ?? null },
-              create: { omiSessionId: sessionRow.id, omiSegmentId, text, speaker: seg.speaker || null, speakerId: (seg.speaker_id ?? seg.speakerId ?? null), isUser: seg.is_user ?? null, start: seg.start ?? null, end: seg.end ?? null }
-            });
-          } catch {}
+        try {
+          sessionRowCache = await prisma.omiSession.findUnique({
+            where: { omiSessionId: String(session_id) },
+            include: { user: true, preferences: true }
+          });
+        } catch {}
+        if (!linkedUserId && sessionRowCache?.userId) {
+          linkedUserId = sessionRowCache.userId;
         }
       }
 
-      const { pref, regex } = await loadActivationConfig(session_id);
+      const { pref, regex } = await loadActivationConfig(session_id, linkedUserId, sessionRowCache);
 
       // Meeting transcribe special mode: only persist (already done) and optionally return on end
       if (pref.meetingTranscribe) {
@@ -198,9 +261,11 @@ module.exports = function createOmiRoutes({ app, prisma, openai, OPENAI_MODEL, E
       let memoryContext = '';
       if (pref.injectMemories && ENABLE_USER_SYSTEM && prisma) {
         try {
-          const sessionRow = await prisma.omiSession.findUnique({ where: { omiSessionId: String(session_id) } });
-          if (sessionRow && sessionRow.userId) {
-            const mems = await prisma.memory.findMany({ where: { userId: sessionRow.userId }, orderBy: { createdAt: 'desc' }, take: 20 });
+          const sessionRow = sessionRowCache || await prisma.omiSession.findUnique({ where: { omiSessionId: String(session_id) } });
+          if (sessionRow && !sessionRowCache) sessionRowCache = sessionRow;
+          const userIdForMemories = (sessionRow && sessionRow.userId) || linkedUserId || null;
+          if (userIdForMemories) {
+            const mems = await prisma.memory.findMany({ where: { userId: userIdForMemories }, orderBy: { createdAt: 'desc' }, take: 20 });
             memoryContext = mems.map((m) => `- ${m.text}`).join('\n');
             if (memoryContext.length > 2000) memoryContext = memoryContext.slice(0, 2000);
           }
@@ -215,7 +280,8 @@ module.exports = function createOmiRoutes({ app, prisma, openai, OPENAI_MODEL, E
       let conversationId = null;
       if (ENABLE_USER_SYSTEM && prisma) {
         try {
-          const sessionRow = await prisma.omiSession.findUnique({ where: { omiSessionId: String(session_id) } });
+          const sessionRow = sessionRowCache || await prisma.omiSession.findUnique({ where: { omiSessionId: String(session_id) } });
+          if (sessionRow && !sessionRowCache) sessionRowCache = sessionRow;
           if (sessionRow && sessionRow.openaiConversationId) {
             conversationId = sessionRow.openaiConversationId;
           }
@@ -225,9 +291,7 @@ module.exports = function createOmiRoutes({ app, prisma, openai, OPENAI_MODEL, E
         try {
           const conversation = await openai.conversations.create({ metadata: { omi_session_id: String(session_id) } });
           conversationId = conversation.id;
-          if (ENABLE_USER_SYSTEM && prisma) {
-            try { await prisma.omiSession.update({ where: { omiSessionId: String(session_id) }, data: { openaiConversationId: conversationId } }); } catch {}
-          }
+          if (sessionRowCache) sessionRowCache.openaiConversationId = conversationId;
         } catch {}
       }
 
@@ -260,34 +324,85 @@ module.exports = function createOmiRoutes({ app, prisma, openai, OPENAI_MODEL, E
       console.log('Webhook response time:', Date.now() - startTime, 'ms');
 
       // Background persistence and notifications
-      if (ENABLE_USER_SYSTEM && prisma && conversationId) {
+      if (ENABLE_USER_SYSTEM && prisma) {
+        const backgroundSessionId = String(session_id);
+        const backgroundSegments = Array.isArray(segments) ? segments.slice() : [];
+        const backgroundLinkedUserId = linkedUserId;
+        const backgroundConversationId = conversationId ? String(conversationId) : null;
+        const backgroundQuestion = question;
+        const backgroundAiResponse = aiResponse;
         setImmediate(async () => {
           try {
-            const sessionRow = await prisma.omiSession.findUnique({ where: { omiSessionId: String(session_id) } });
-            if (!sessionRow) return;
-            const conversationRow = await prisma.conversation.upsert({
-              where: { omiSessionId_openaiConversationId: { omiSessionId: sessionRow.id, openaiConversationId: String(conversationId) } },
-              update: {},
-              create: { omiSessionId: sessionRow.id, openaiConversationId: String(conversationId) }
+            const sessionUpdate = { lastSeenAt: new Date() };
+            const sessionCreate = { omiSessionId: backgroundSessionId };
+            if (backgroundLinkedUserId) {
+              sessionUpdate.userId = backgroundLinkedUserId;
+              sessionCreate.userId = backgroundLinkedUserId;
+            }
+            if (backgroundConversationId) {
+              sessionUpdate.openaiConversationId = backgroundConversationId;
+              sessionCreate.openaiConversationId = backgroundConversationId;
+            }
+            const sessionRow = await prisma.omiSession.upsert({
+              where: { omiSessionId: backgroundSessionId },
+              update: sessionUpdate,
+              create: sessionCreate
             });
-            await prisma.message.create({ data: { conversationId: conversationRow.id, role: 'USER', text: question, source: 'OMI_TRANSCRIPT' } });
-            await prisma.message.create({ data: { conversationId: conversationRow.id, role: 'ASSISTANT', text: aiResponse, source: 'SYSTEM' } });
-            if (sessionRow.userId) {
-              const userId = sessionRow.userId;
-              let active = await prisma.userContextWindow.findFirst({ where: { userId, isActive: true } });
-              if (!active) {
-                const existingSlot1 = await prisma.userContextWindow.findUnique({ where: { userId_slot: { userId, slot: 1 } } });
-                if (!existingSlot1) {
-                  await prisma.userContextWindow.create({ data: { userId, slot: 1, conversationId: conversationRow.id, isActive: true } });
-                } else {
-                  await prisma.userContextWindow.update({ where: { userId_slot: { userId, slot: 1 } }, data: { conversationId: conversationRow.id, isActive: true } });
-                }
-              } else {
-                await prisma.userContextWindow.update({ where: { userId_slot: { userId, slot: active.slot } }, data: { conversationId: conversationRow.id } });
+            const sessionRowId = sessionRow?.id;
+
+            if (sessionRowId && backgroundSegments.length) {
+              try {
+                const operations = backgroundSegments.map((seg) => {
+                  if (!seg) return Promise.resolve();
+                  const text = String(seg.text || '');
+                  const omiSegmentId = String(seg.id || seg.segment_id || crypto.createHash('sha1').update(text).digest('hex'));
+                  return prisma.transcriptSegment.upsert({
+                    where: { omiSessionId_omiSegmentId: { omiSessionId: sessionRowId, omiSegmentId } },
+                    update: { text, speaker: seg.speaker || null, speakerId: (seg.speaker_id ?? seg.speakerId ?? null), isUser: seg.is_user ?? null, start: seg.start ?? null, end: seg.end ?? null },
+                    create: { omiSessionId: sessionRowId, omiSegmentId, text, speaker: seg.speaker || null, speakerId: (seg.speaker_id ?? seg.speakerId ?? null), isUser: seg.is_user ?? null, start: seg.start ?? null, end: seg.end ?? null }
+                  }).catch((err) => {
+                    console.error('Transcript segment upsert failed:', err);
+                  });
+                });
+                await Promise.all(operations);
+              } catch (err) {
+                console.error('Background transcript persistence failed:', err);
               }
             }
-          } catch (e) {
-            console.error('Background conversation save failed:', e);
+
+            if (sessionRowId && backgroundConversationId) {
+              try {
+                const conversationRow = await prisma.conversation.upsert({
+                  where: { omiSessionId_openaiConversationId: { omiSessionId: sessionRowId, openaiConversationId: backgroundConversationId } },
+                  update: {},
+                  create: { omiSessionId: sessionRowId, openaiConversationId: backgroundConversationId }
+                });
+                if (backgroundQuestion) {
+                  await prisma.message.create({ data: { conversationId: conversationRow.id, role: 'USER', text: backgroundQuestion, source: 'OMI_TRANSCRIPT' } });
+                }
+                if (backgroundAiResponse) {
+                  await prisma.message.create({ data: { conversationId: conversationRow.id, role: 'ASSISTANT', text: backgroundAiResponse, source: 'SYSTEM' } });
+                }
+                if (sessionRow.userId) {
+                  const userId = sessionRow.userId;
+                  let active = await prisma.userContextWindow.findFirst({ where: { userId, isActive: true } });
+                  if (!active) {
+                    const existingSlot1 = await prisma.userContextWindow.findUnique({ where: { userId_slot: { userId, slot: 1 } } });
+                    if (!existingSlot1) {
+                      await prisma.userContextWindow.create({ data: { userId, slot: 1, conversationId: conversationRow.id, isActive: true } });
+                    } else {
+                      await prisma.userContextWindow.update({ where: { userId_slot: { userId, slot: 1 } }, data: { conversationId: conversationRow.id, isActive: true } });
+                    }
+                  } else {
+                    await prisma.userContextWindow.update({ where: { userId_slot: { userId, slot: active.slot } }, data: { conversationId: conversationRow.id } });
+                  }
+                }
+              } catch (err) {
+                console.error('Background conversation save failed:', err);
+              }
+            }
+          } catch (err) {
+            console.error('Background session persistence failed:', err);
           }
         });
       }


### PR DESCRIPTION
## Summary
- detect memory metadata separately from transcript segments so the webhook can respond even when both arrive together
- persist memories inline only when no transcript data is present and defer combined memory/transcript saves to a background task
- include optional `memory_segments` when composing memory text to keep structured payloads intact

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68d1a9bd84cc832d8637ff7d7902c3c4